### PR TITLE
fix(auth): allow google oauth avatars to be displayed

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+      },
+    ],
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
Previously the google domain for avatars was not allowed in the config.
This would lead to Next.js's Image component not displaying them.
