### PR TITLE
build(next): do not run eslint during next build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,9 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
Next.js runs eslint during build by default, however since we run eslint
ourselves in CI, running it again is redundant.
