### PR TITLE
ci: refactor workflows with composite setup action and split jobs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,22 @@
+name: "Setup Node + pnpm"
+description: "Sets up Node.js , pnpm and install deps"
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+      with:
+        run_install: |
+          - recursive: false
+            args: [--frozen-lockfile, --strict-peer-dependencies]
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: "pnpm"
+
+inputs:
+  node-version:
+    description: "Node.js version"
+    required: false
+    default: "20"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,19 +20,65 @@ on:
       - ".eslintrc*"
       - ".prettierrc*"
 
+permissions:
+  contents: read
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
+env:
+  CI: true
+  NEXT_TELEMETRY_DISABLED: 1
+
 jobs:
-  lint-and-build:
+
+
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
           node-version: 20
-          cache: 'pnpm'
+      - run: pnpm lint
 
-      - run: pnpm check
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
+        with:
+          node-version: 20
+
+      - run: pnpm format:check
+
+  typecheck:
+    runs-on: ubuntu-latest
+    needs: [lint, format]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
+        with:
+          node-version: 20
+
+      - run: pnpm typecheck
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [typecheck]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
+        with:
+          node-version: 20
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+
+      - run: pnpm build

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,9 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
### Changes
- **Composite Action**
  - Added `.github/actions/setup/action.yml`
  - Handles Node.js + pnpm installation with caching
  - Provides configurable `node-version` input (default: 20)

- **Workflow**
  - Replaced single `lint-and-build` job with four separate jobs:
    - `lint`
    - `format`
    - `typecheck`
    - `build`
  - Added workflow-level permissions, concurrency controls, and environment variables
  - Added cache step for `.next/cache` in build job
  - Refactored jobs to use the new composite action

- **Next.js**
  - Updated `next.config.ts` to disable eslint during build (avoiding redundant lint checks since lint runs separately in CI)

### Commits
- `17b435ce24ecd2e377e5029647fbae0ff5d81e85` — ci: add setup composite action and refactor workflow into separate jobs
- `46b92d27988b9d9c9513aa3c1318e23ef277adc5` — build(next): do not run eslint during next build

### Motivation
- Speeds up CI by caching dependencies and build artifacts
- Simplifies maintenance by consolidating setup logic into a composite action
- Improves workflow clarity and separation of concerns
- Prevents double linting (once during lint job, again during Next.js build)
