### PR TITLE
feature/use cache properly

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,15 +5,14 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@v4
-      with:
-        run_install: |
-          - recursive: false
-            args: [--frozen-lockfile, --strict-peer-dependencies]
 
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: "pnpm"
+
+    - run: pnpm install --frozen-lockfile --strict-peer-dependencies
+      shell: bash
 
 inputs:
   node-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ on:
       - ".eslintrc*"
       - ".prettierrc*"
 
+  workflow_dispatch:
+
 permissions:
   contents: read
 


### PR DESCRIPTION
- **ci(workflow): ensure the cache step runs before pnpm install**
  Previously, pnpm install would run before the caching step was ran,
  resulting in unnecessary work being performed on each run.
  

- **ci(workflow): add workflow dispatch for manual runs**
  